### PR TITLE
made changes in model.py and added support make predictions in terminal

### DIFF
--- a/team_ops/conf/config.yaml
+++ b/team_ops/conf/config.yaml
@@ -13,7 +13,7 @@ data:
 
 train:
   output_path: 'models' # Path to save the trained model
-  model_name: 'model_1'
+  model_name: 'model_1' # Change the name of the model as needed.
   learning_rate: 2e-5
   per_device_train_batch_size: 8
   per_device_eval_batch_size: 8
@@ -23,3 +23,5 @@ train:
   save_strategy: 'epoch'
   load_best_model_at_end: True
   push_to_hub: False
+  # Set this to true if you want to retrain even though you have a trained model. 
+  force_train: False

--- a/team_ops/model.py
+++ b/team_ops/model.py
@@ -166,7 +166,11 @@ class Model(HConfig):
         train_args = self._cfg["train"]
         out_dir = f"{train_args['output_path']}/{train_args['model_name']}"
 
-        if os.path.exists(out_dir) and not self._model_loaded:
+        if (
+            os.path.exists(out_dir)
+            and not self._model_loaded
+            and not self._cfg["train"]["force_train"]
+        ):
             self._log.info("Model already exists. Skipping training.")
             self.load_model()
             return

--- a/team_ops/predict_model.py
+++ b/team_ops/predict_model.py
@@ -11,25 +11,15 @@ def main():
     # Get the dataset
     model.load_model()
 
-    # Train the model
-    prediction = model.predict(
-        """
-        We present an independent discovery and detailed characterisation of K2-280b, 
-        a transiting low density warm sub-Saturn in a 19.9-day moderately eccentric orbit 
-        (e = 0.35_{-0.04}^{+0.05}) from K2 campaign 7. A joint analysis of high precision HARPS,
-        HARPS-N, and FIES radial velocity measurements and K2 photometric data indicates that
-        K2-280b has a radius of R_b = 7.50 +/- 0.44 R_Earth and a mass of M_b = 37.1 +/- 5.6 M_Earth,
-        yielding a mean density of 0.48_{-0.10}^{+0.13} g/cm^3. The host star is a mildly 
-        evolved G7 star with an effective temperature of T_{eff} = 5500 +/- 100 K,
-        a surface gravity of log(g) = 4.21 +/- 0.05 (cgs), and an iron abundance 
-        of [Fe/H] = 0.33 +/- 0.08 dex, and with an inferred mass of M_star = 1.03 +/- 0.03 M_sun and 
-        a radius of R_star = 1.28 +/- 0.07 R_sun. We discuss the importance of K2-280b for 
-        testing formation scenarios of sub-Saturn planets and the current sample of this 
-        intriguing group of planets that are absent in the Solar System. 
-    """
-    )
+    while True:
+        prompt = input("Enter the prompt (Type `exit` to quit!!): ")
+        if prompt.lower() == "exit":
+            break
+        prediction = model.predict(prompt)
 
-    print(prediction)
+        print("--------------------")
+        print(f"{prediction}")
+        print("--------------------")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
model.py now supports force training. This is when user wants to retrain the model, even though the model exists. Might just work if user changes the name of the model to store.
predict_model.py: Added input statement to receive inputs from the terminal.